### PR TITLE
Format archive URL as key-value pair in extra field

### DIFF
--- a/chrome/content/scripts/IaPusher.js
+++ b/chrome/content/scripts/IaPusher.js
@@ -124,7 +124,7 @@ Zotero.IaPusher = {
           return;
         }
 
-        item.setField("extra", item.getField("extra") +"; " + archivedUrl);
+        item.setField("extra", item.getField("extra") +"\nMemento: " + archivedUrl);
       }
       else {
         item.setField("extra", archivedUrl);


### PR DESCRIPTION
Thanks for this great extension! 

I suggest creating a proper key-value entry for the archive URL in the extra field. This avoids problems when using several entries in extra, e.g., when simultaneously using the Citation Key entry of [BetterBibTeX](https://github.com/retorquere/zotero-better-bibtex). Moreover, it facilitates accessing the archive URL in CSL as it corresponds to the [official recommendation for citing fields from extra](https://github.com/retorquere/zotero-better-bibtex)).